### PR TITLE
IDs remapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN sed -i "s/www-data/nginx/g" /etc/init.d/fcgiwrap
 # manage start container
 RUN mkdir /usr/share/gitweb/docker-entrypoint.pre
 RUN mkdir /usr/share/gitweb/docker-entrypoint.post
-COPY ./src/00_init.sh /usr/share/gitweb/docker-entrypoint.pre/00_init.sh
+COPY ./src/00_user_ids.sh /usr/share/gitweb/docker-entrypoint.pre/00_user_ids.sh
+COPY ./src/01_git_projects.sh /usr/share/gitweb/docker-entrypoint.pre/01_git_projects.sh
+COPY ./src/02_auth.sh /usr/share/gitweb/docker-entrypoint.pre/02_auth.sh
 RUN chmod +x -R /usr/share/gitweb/docker-entrypoint.pre
 
 # add cmd gitweb

--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ load when start image load file in
 - GITUSER (default gituser)
 - GITPASSWORD (default gitpassword)
 - IHM (default "")
+- UID_REMAP (default ""): to set `nginx`'s UID
+- GID_REMAP (default ""): to set `nginx`'s primary GID
 
 ## Volume
 
 - /var/lib/git
+
+**NOTE**: by default all r/w access to contents of repositories inside the volume is made by `nginx:nginx` user. When the volume is mounted externally, that makes sense to make `nginx`'s user to reflects runner's ID and GID from the host. Otherwise access issues is thing to deal with.
+
+Basically: `docker run [...] -e UID_REMAP=$(id -u) -e GID_REMAP=$(id -g) [...]`
 
 ## Port
 

--- a/src/00_user_ids.sh
+++ b/src/00_user_ids.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -n "${UID_REMAP}" ]; then
+    # TODO: check for container's UID existence
+    usermod -u ${UID_REMAP} nginx
+fi
+
+if [ -n "${GID_REMAP}" ]; then
+    getent group ${GID_REMAP} || addgroup --gid ${GID_REMAP} group_${GID_REMAP}_from_host
+    usermod -g ${GID_REMAP} nginx
+fi

--- a/src/01_git_projects.sh
+++ b/src/01_git_projects.sh
@@ -11,7 +11,3 @@ for GITPROJECT in $(echo "${GITPROJECTS}" | tr , '\n'); do
     chmod -R g+ws .
     chgrp -R nginx .
 done
-
-if [ ! -z "$GITUSER" ]; then
-    addauth $GITUSER $GITPASSWORD
-fi 

--- a/src/02_auth.sh
+++ b/src/02_auth.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ ! -z "$GITUSER" ]; then
+    addauth $GITUSER $GITPASSWORD
+fi


### PR DESCRIPTION
- `UID_REMAP` & `GID_REMAP` env options introduced to change `nginx`'s IDs for correct access to externally mounted git repositories (via pre-run script)
- `00_init.sh` is split to multiple files / per scope