### PR TITLE
Allow .htpasswd to be mounted as a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN chmod +x /entrypoint.sh
 
 ENV SET_CONTAINER_TIMEZONE false 
 ENV CONTAINER_TIMEZONE "" 
+ENV _HTPASSWD /etc/nginx/.htpasswd
+ENV _BASE_HTPASSWD /etc/nginx/htpasswd.base
 
 RUN apt-get update && apt-get install -y \
         apache2-utils \
@@ -53,6 +55,7 @@ RUN cp /usr/share/gitweb/static/gitweb.css /usr/share/gitweb/static/gitweb.css.o
 RUN mkdir /usr/share/gitweb/ihm
 
 VOLUME /var/lib/git
+VOLUME /etc/nginx/htpasswd.base
 EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -9,18 +9,21 @@ load when start image load file in
 
 ## Parameter
 
-- SET_CONTAINER_TIMEZONE (false or true) manage time of container
-- CONTAINER_TIMEZONE timezone of container
-- GITPROJECTS (list of projects separated with `,`)
-- GITUSER (default gituser)
-- GITPASSWORD (default gitpassword)
-- IHM (default "")
-- UID_REMAP (default ""): to set `nginx`'s UID
-- GID_REMAP (default ""): to set `nginx`'s primary GID
+- `SET_CONTAINER_TIMEZONE` (false or true) manage time of container
+- `CONTAINER_TIMEZONE` timezone of container
+- `GITPROJECTS` (list of projects separated with `,`)
+- `GITUSER` (default: `gituser`)
+- `GITPASSWORD` (default: `gitpassword`)
+- `IHM` (default: `""`)
+- `UID_REMAP` (default: `""`): to set `nginx`'s UID
+- `GID_REMAP` (default: `""`): to set `nginx`'s primary GID
+
+**NOTE**: `GITUSER` & `GITPASSWORD` are not taken into account when `/etc/nginx/htpasswd.base` volume is mounted. They should be added explicitly then.
 
 ## Volume
 
 - /var/lib/git
+- /etc/nginx/htpasswd.base
 
 **NOTE**: by default all r/w access to contents of repositories inside the volume is made by `nginx:nginx` user. When the volume is mounted externally, that makes sense to make `nginx`'s user to reflects runner's ID and GID from the host. Otherwise access issues is thing to deal with.
 
@@ -36,6 +39,8 @@ Basically: `docker run [...] -e UID_REMAP=$(id -u) -e GID_REMAP=$(id -g) [...]`
 - addauth : add user for git
 - rmrepos : remove repository
 - rmauth : remove user
+
+**NOTE**: keep in mind `htpasswd.base`'s ACL once it is mounted as a volume.
 
 ## Usage direct
 

--- a/src/02_auth.sh
+++ b/src/02_auth.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-if [ ! -z "$GITUSER" ]; then
+if [ -f "${_BASE_HTPASSWD}" ]; then
+    cp ${_BASE_HTPASSWD} ${_HTPASSWD}
+fi
+
+if [ -n "$GITUSER" -a ! -e ${_HTPASSWD} ]; then
     addauth $GITUSER $GITPASSWORD
 fi

--- a/src/cmd/addauth.sh
+++ b/src/cmd/addauth.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-FPASS="/etc/nginx/.htpasswd"
  
 error(){ 
     	echo "ERROR : parameters invalid !" >&2 
@@ -12,11 +11,11 @@ usage(){
 } 
 
 load(){
-	if [ ! -f $FPASS ]; then
-  		htpasswd -bc $FPASS $1 $2
-	else
-      htpasswd -b $FPASS $1 $2 
-	fi
+    if [ ! -f ${_HTPASSWD} ]; then
+        htpasswd -bc ${_HTPASSWD} $1 $2
+    else
+        htpasswd -b ${_HTPASSWD} $1 $2
+    fi
 }
 
 # no parameters

--- a/src/cmd/rmauth.sh
+++ b/src/cmd/rmauth.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-FPASS="/etc/nginx/.htpasswd"
  
 error(){ 
     	echo "ERROR : parameters invalid !" >&2 
@@ -12,9 +11,9 @@ usage(){
 } 
 
 load(){
-	if [ -f $FPASS ]; then
-  		htpasswd -bD $FPASS $1
-	fi
+    if [ -f ${_HTPASSWD} ]; then
+        htpasswd -bD ${_HTPASSWD} $1
+    fi
 }
 
 # no parameters


### PR DESCRIPTION
`/etc/nginx/htpasswd.base` volume has been introduced to allow use the file as a bootstrap foundation for `.htpasswd`.